### PR TITLE
fixed conditional logic bug in calc.peakTime and misspecified regex i…

### DIFF
--- a/reaRate/R/def.calc.peakTime.R
+++ b/reaRate/R/def.calc.peakTime.R
@@ -64,7 +64,7 @@ def.calc.peakTime <- function(
   Sys.sleep(1)
   invisible(dev.off())
   
-  if(badPlotBox==1){
+  if(length(badPlotBox) && badPlotBox==1){
     #If things look good, move on
     invisible(dev.new(noRStudioGD = TRUE))
     plot(seq(along=loggerData), loggerData, xlab = "Measurement Number", ylab = "Specific Conductance")

--- a/reaRate/R/def.calc.reaeration.R
+++ b/reaRate/R/def.calc.reaeration.R
@@ -171,9 +171,9 @@ def.calc.reaeration <- function(
     stringsAsFactors = F)
   
   #Check for correct date format
-  if(all(grepl("20[1-9][0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",loggerData$dateTimeLogger))){
+  if(all(grepl("20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",loggerData$dateTimeLogger))){
     dateFormat <- "%Y-%m-%dT%H:%M:%SZ"
-  }else if(all(grepl("20[1-9][0-9]-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.000\\+0000",loggerData$dateTimeLogger))){
+  }else if(all(grepl("20[0-9]-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.000\\+0000",loggerData$dateTimeLogger))){
     dateFormat <- "%Y-%m-%dT%H:%M:%S.000+0000"
   }else{
     stop("Inconsistent or unidentified date formats in conductivity logger data.")


### PR DESCRIPTION
…n calc.rearation.

In addition to these issues, the docs for def.calc.reaeration do not mention that loggerFile should be conductivity field data, or where that might be found. I specified dataDir='API', site='all', and fieldQ=TRUE in my call to def.format.reaeration, which placed the conductivity data file in filesToStack20190/stackedFiles.